### PR TITLE
Actualizada página de SALIDA que permite salir y destruir la COOKIE

### DIFF
--- a/0029-ProyectoPHP/salidaPagina.php
+++ b/0029-ProyectoPHP/salidaPagina.php
@@ -1,5 +1,6 @@
 <?php
     session_start();
     session_destroy();
-    header("location:PHP_login.php");
+    setcookie("nombre_usuario","Rasselin",time()-1);
+    header("location:PHP_Login.php");
 ?>


### PR DESCRIPTION
Faltó configurar la página de salida del sitio web:
- Destruir la COOKIE creada
- Regresar al LOGIN inicial que se había creado